### PR TITLE
Use ActivityTestRule instead of ActivityInstrumentationTestCase2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,8 +51,9 @@ dependencies {
 	androidTestCompile 'org.hamcrest:hamcrest-core:1.1'
 	androidTestCompile 'org.hamcrest:hamcrest-library:1.1'
 	androidTestCompile 'org.hamcrest:hamcrest-integration:1.1'
-	androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
-	androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
+	androidTestCompile 'com.android.support.test.espresso:espresso-core:2.1'
+	androidTestCompile 'com.android.support.test:runner:0.2'
+	androidTestCompile 'com.android.support.test:rules:0.2'
 }
 
 

--- a/app/src/androidTest/java/com/example/android/tests/instrumentation/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/android/tests/instrumentation/MainActivityTest.java
@@ -1,11 +1,13 @@
 package com.example.android.tests.instrumentation;
 
-import android.test.ActivityInstrumentationTestCase2;
+import android.support.test.rule.ActivityTestRule;
 import android.test.suitebuilder.annotation.LargeTest;
-
 
 import com.example.android.app.MainActivity;
 import com.example.android.app.R;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -13,25 +15,14 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 @LargeTest
-public class MainActivityTest extends ActivityInstrumentationTestCase2<MainActivity> {
+public class MainActivityTest {
 
-	@SuppressWarnings("deprecation")
-	public MainActivityTest() {
-		// This constructor was deprecated - but we want to support lower API levels.
-		super("com.example.android.app", MainActivity.class);
-	}
+	@Rule
+	public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 
-
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-		// Espresso will not launch our activity for us, we must launch it via getActivity().
-		getActivity();
-	}
-
+	@Test
 	public void testCheckText() {
 		onView(withId(R.id.hello_world))
 				.check(matches(withText("Hello world!")));
 	}
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:1.2.2'
+		classpath 'com.android.tools.build:gradle:1.2.3'
 	}
 }
 


### PR DESCRIPTION
I tested on API10 and API22 vms. That deprecated constructor looks to be from API8 though, so I am not sure if this still accomplishes what you wanted there.

Also the robolectric tests won't run for me even before the changes, failing with a NoSuchMethodError. I assume it's unrelated.
